### PR TITLE
Update Piper Merriam & Jason Carver's profile information

### DIFF
--- a/source/_people/jason-carver.md
+++ b/source/_people/jason-carver.md
@@ -1,8 +1,8 @@
 ---
 name: Jason Carver
-description: Senior Staff Engineer
+description: Python & Rust Core Developer
 start: May 2017
-end: present
+end: July 2025
 social:
   github: https://github.com/carver
   twitter: https://x.com/jasoncarver

--- a/source/_people/piper-merriam.md
+++ b/source/_people/piper-merriam.md
@@ -1,7 +1,7 @@
 ---
 name: Piper Merriam
 start: May 2017
-end: present
+end: July 2025
 social:
   github: https://github.com/pipermerriam
   twitter: https://x.com/pipermerriam


### PR DESCRIPTION
A number of people left the EF in July this year. Piper and I were among them.

This update notes that. It also gives a slightly more context-aware job title than my LinkedIn bio.