### PR TITLE
Fix local development instructions to prevent config loading error

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ EarlyDaysOfEthereum/
 # Install dependencies
 bundle install
 
-# Run development server
-bundle exec jekyll serve --source source
+# Run development server (from project root)
+bundle exec jekyll serve
 
 # Access at http://localhost:4000
 ```
+
+**Note:** Do NOT use `--source source` flag. The `_config.yml` at the project root already specifies `source: source`. Running with the flag causes Jekyll to miss the config file, resulting in build errors like "Cannot sort a null object" because collections aren't loaded.
 
 ### Collections
 


### PR DESCRIPTION
## Summary
- Remove `--source source` flag from `jekyll serve` command in README
- Add note explaining why the flag should not be used
- The `_config.yml` already specifies `source: source`, so using the flag causes Jekyll to miss the config file and fail with null collection errors

## Test plan
- [ ] Run `bundle exec jekyll serve` from project root
- [ ] Verify site builds successfully and serves at http://localhost:4000

🤖 Generated with [Claude Code](https://claude.com/claude-code)