### PR TITLE
Enhance people profiles from Episode 12 interview

### DIFF
--- a/source/_people/bob-summerwill.md
+++ b/source/_people/bob-summerwill.md
@@ -80,6 +80,12 @@ Bob created this project to preserve and document Ethereum's founding history—
 
 > "There is no canonical history of any of this. Like, how did Ethereum start? I mean, it's in people's heads - all secondhand stories that you hear from people that were around. But it's like, what's true, what isn't?"
 
-## Primary Source
+Fabian Vogelsteller called Bob "the archivist of Ethereum" and emphasized the importance of the work:
 
-This profile draws from [Bob Summerwill's Early Days of Ethereum interview](/videos/episode003-bob-summerwill/), where he discussed his journey into Ethereum, the C++ client development, The DAO hack, and the emergence of Ethereum Classic.
+> "You are the archivist of Ethereum and you really, with that, hold up the true story and the participants and the contributions and make that visible and transparent to people... Honestly, like the Ethereum Foundation should give you a little grant for that, for doing that work. Because honestly, like no one does it and it's such an important work for people later to understand." — Fabian Vogelsteller ([Episode 12](/videos/episode012-fabian-vogelsteller/))
+
+## Primary Sources
+
+This profile draws from:
+- [Bob Summerwill's Early Days of Ethereum interview](/videos/episode003-bob-summerwill/), where he discussed his journey into Ethereum, the C++ client development, The DAO hack, and the emergence of Ethereum Classic
+- [Episode 12](/videos/episode012-fabian-vogelsteller/) with Fabian Vogelsteller

--- a/source/_people/christian-reitwiessner.md
+++ b/source/_people/christian-reitwiessner.md
@@ -11,4 +11,15 @@ social:
   github: https://github.com/chriseth
 ---
 
+Christian Reitwießner was the lead developer of [Solidity](/articles/solidity/), Ethereum's primary smart contract programming language, which he designed alongside [Gavin Wood](/people/gavin-wood/). He joined the Ethereum Foundation in October 2014 and was based in the Berlin ETHDEV office, where he worked for nearly a decade.
 
+Fabian Vogelsteller, who sat in the same Berlin office building the [Mist](/articles/mist/) browser and [web3.js](https://github.com/ethereum/web3.js), described working closely with him:
+
+> "I talked and worked with Christian a lot who worked on Solidity, was also in the Berlin office." — Fabian Vogelsteller ([Episode 12](/videos/episode012-fabian-vogelsteller/))
+
+At DEVCON3 in Cancún (November 2017), Christian was introduced alongside Vitalik Buterin, Peter Szilagyi, Fabian Vogelsteller, and Viktor Tron as one of the Ethereum team leads.
+
+## Primary Sources
+
+- [Episode 12](/videos/episode012-fabian-vogelsteller/) with Fabian Vogelsteller on the Berlin office team
+- [Gav's ÐΞV Update I](/articles/gavs-dev-update-i/) through [V](/articles/gavs-dev-update-v/) on the C++ team

--- a/source/_people/christoph-jentzsch.md
+++ b/source/_people/christoph-jentzsch.md
@@ -34,6 +34,10 @@ His test infrastructure became the authoritative source for protocol correctness
 
 > "They were saying, okay, now if Christoph doesn't find any failing tests for like three weeks or four weeks or something, we are ready."
 
+Fabian Vogelsteller, who shared the Berlin office, recalled Christoph's role and frequent presence:
+
+> "Christoph Jentzsch came to the Berlin office frequently. He was more like hired as a kind of contractor to do testing, testing scenarios for the nodes. So he wrote all these kind of tests to test all kind of inputs and outputs of node behavior... cross-client, make sure this all functions correctly." — Fabian Vogelsteller ([Episode 12](/videos/episode012-fabian-vogelsteller/))
+
 ## DEVCON0
 
 Christoph was present at [DEVCON0](/articles/devcon0/) in Berlin, which he described as an internal company retreat rather than a public conference:
@@ -128,6 +132,8 @@ He has attended every Devcon since DEVCON0:
 
 > "It's like only once in a lifetime, or two times in a lifetime, you have this moment where everything comes together: the right time, the right place, the right people. This certainly—those one and a half years I worked for Ethereum—are definitely the prime of my career in terms of who I worked with, what we accomplished, the impact we had on the world, and the sweet cypherpunk spirit there."
 
-## Primary Source
+## Primary Sources
 
-This profile draws from [Christoph Jentzsch's Early Days of Ethereum interview](/videos/episode006-christoph-jentzsch/), which provides first-hand accounts of Ethereum's testing infrastructure, the Frontier launch, and the full arc from Slock.it through The DAO.
+This profile draws from:
+- [Christoph Jentzsch's Early Days of Ethereum interview](/videos/episode006-christoph-jentzsch/), which provides first-hand accounts of Ethereum's testing infrastructure, the Frontier launch, and the full arc from Slock.it through The DAO
+- [Episode 12](/videos/episode012-fabian-vogelsteller/) with Fabian Vogelsteller on the Berlin office team

--- a/source/_people/fabian-vogelsteller.md
+++ b/source/_people/fabian-vogelsteller.md
@@ -15,7 +15,7 @@ Fabian Vogelsteller is the author of the [ERC-20](https://eips.ethereum.org/EIPS
 
 ## Background
 
-Before Ethereum, Fabian was a web developer based in Berlin. He built websites from age 14, created a flat-file PHP content management system called [Feindura](https://feindura.org) (which became his online identity), and later became deeply involved with [Meteor.js](https://www.meteor.com), one of the first reactive JavaScript frameworks. He wrote [a book about building single-page apps with Meteor](https://www.packtpub.com/product/building-single-page-web-apps-with-meteor/9781783988129)—experience that proved directly relevant to building dapps:
+Before Ethereum, Fabian was a web developer based in Berlin. He built websites from age 14, created a flat-file PHP content management system called [Feindura](https://web.archive.org/web/20141217063119/http://feindura.org/) (which became his online identity), and later became deeply involved with [Meteor.js](https://www.meteor.com), one of the first reactive JavaScript frameworks. He wrote [a book about building single-page apps with Meteor](https://www.packtpub.com/product/building-single-page-web-apps-with-meteor/9781783988129)—experience that proved directly relevant to building dapps:
 
 > "What is this writing single page apps with Meteor. And what is a dapp? It's a single page app."
 

--- a/source/_people/gustav-simonssen.md
+++ b/source/_people/gustav-simonssen.md
@@ -5,3 +5,12 @@ social:
   github: https://github.com/Gustav-Simonsson
 ---
 
+Gustav Simonssen was a Go developer who built a key manager implementation in [go-ethereum (Geth)](/articles/geth/). He was one of many developers drawn to the Berlin ETHDEV office, which functioned as an informal Ethereum hub in 2015.
+
+Fabian Vogelsteller recalled Gustav as one of the people who "just showed up" at the Berlin office and became friends with the team:
+
+> "People that I met that like really became friends. Gustav Simonssen who built a key manager implementation in go-ethereum." — Fabian Vogelsteller ([Episode 12](/videos/episode012-fabian-vogelsteller/))
+
+## Primary Sources
+
+- [Episode 12](/videos/episode012-fabian-vogelsteller/) with Fabian Vogelsteller on the Berlin office

--- a/source/_people/liana-husikyan.md
+++ b/source/_people/liana-husikyan.md
@@ -8,3 +8,10 @@ social:
   twitter: https://x.com/LianaHusikyan
 ---
 
+Liana Husikyan worked on [Mix](/articles/mix/) and later [Remix](https://remix.ethereum.org/) alongside [Yann Levreau](/people/yann-levreau/) in the Berlin ETHDEV office. She sat across from Fabian Vogelsteller, who was building the [Mist](/articles/mist/) browser and [web3.js](https://github.com/ethereum/web3.js).
+
+> "The other girl that worked on the Remix, Liana Husikyan, was sitting across me in the Berlin office." — Fabian Vogelsteller ([Episode 12](/videos/episode012-fabian-vogelsteller/))
+
+## Primary Sources
+
+- [Episode 12](/videos/episode012-fabian-vogelsteller/) with Fabian Vogelsteller on the Berlin office team


### PR DESCRIPTION
## Summary
- Add new profiles for Christian Reitwiessner (Solidity lead), Gustav Simonssen (Geth key manager), and Liana Husikyan (Mix/Remix) based on Fabian Vogelsteller's Episode 12 interview
- Add Fabian's "archivist of Ethereum" quote to Bob Summerwill's profile
- Add Fabian's perspective on Christoph Jentzsch's testing contractor role
- Fix dead Feindura link in Fabian Vogelsteller's profile to archive.org URL

## Test plan
- [ ] Verify all new profile pages render correctly
- [ ] Check that people links resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)