### PR TITLE
Fix broken links and backlink nickname handling

### DIFF
--- a/source/_plugins/auto_linker.rb
+++ b/source/_plugins/auto_linker.rb
@@ -215,8 +215,7 @@ module EarlyDays
         nickname = doc.data['nickname']&.tr('"\'', '')
         ids[url] = { url_ns: url.chomp('/'), title: doc.data['title']&.tr('"\'', ''),
                      name: doc.data['name']&.tr('"\'', ''), aka: doc.data['alias']&.tr('"\'', ''),
-                     nickname: nickname,
-                     col: doc.collection.label }
+                     nickname: nickname, col: doc.collection.label }
       end
 
       all_docs.each do |doc|


### PR DESCRIPTION
## Summary
- fix backlink generation for nickname references in the auto linker
- carry forward the remaining broken-link batch change on top of current main
